### PR TITLE
Add food log parser utility

### DIFF
--- a/genie_service/functions/food_parser.py
+++ b/genie_service/functions/food_parser.py
@@ -1,0 +1,41 @@
+import re
+from typing import Dict
+
+TRANSLATION = {
+    "사과": "apple",
+    "바나나": "banana",
+    "우유": "milk",
+}
+
+MEASURE_MAP = {
+    "개": "unit",
+    "잔": "cup",
+    "ml": "ml",
+    "그램": "g",
+    "g": "g",
+}
+
+PATTERN = re.compile(r"(?P<food>\S+)\s+(?P<quantity>[0-9]+(?:\.[0-9]+)?)\s*(?P<measure>\S+)")
+
+def parse_food_log(text: str) -> Dict[str, object]:
+    match = PATTERN.search(text)
+    if not match:
+        raise ValueError(f"Cannot parse input: {text}")
+    food = match.group('food')
+    quantity = float(match.group('quantity'))
+    if quantity.is_integer():
+        quantity = int(quantity)
+    measure = match.group('measure')
+    return {
+        "food": TRANSLATION.get(food, food),
+        "quantity": quantity,
+        "measure": MEASURE_MAP.get(measure, measure)
+    }
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python -m food_parser '<text>'")
+        sys.exit(1)
+    result = parse_food_log(sys.argv[1])
+    print(result)

--- a/genie_service/functions/tests/test_food_parser.py
+++ b/genie_service/functions/tests/test_food_parser.py
@@ -1,0 +1,18 @@
+import unittest
+from genie_service.functions.food_parser import parse_food_log
+
+class TestFoodParser(unittest.TestCase):
+    def test_apple_units(self):
+        data = parse_food_log('사과 2개 먹었어요')
+        self.assertEqual(data, {'food': 'apple', 'quantity': 2, 'measure': 'unit'})
+
+    def test_banana_units(self):
+        data = parse_food_log('바나나 3개 먹었어요')
+        self.assertEqual(data, {'food': 'banana', 'quantity': 3, 'measure': 'unit'})
+
+    def test_milk_ml(self):
+        data = parse_food_log('우유 200ml 마셨어요')
+        self.assertEqual(data, {'food': 'milk', 'quantity': 200, 'measure': 'ml'})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a simple Korean food log parser
- map common foods and measures to English
- expose CLI entry point
- add unit tests for the parser

## Testing
- `python -m unittest discover genie_service/functions/tests`

------
https://chatgpt.com/codex/tasks/task_e_684924de85f48329b6e5edcd4e6f8469