### PR TITLE
Add file-based food log parser

### DIFF
--- a/genie_service/functions/food_file_reader.py
+++ b/genie_service/functions/food_file_reader.py
@@ -1,0 +1,18 @@
+import sys
+from typing import Dict
+from .food_parser import parse_food_log
+
+
+def parse_food_file(path: str) -> Dict[str, object]:
+    """Read a food log from a file and parse it."""
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read().strip()
+    return parse_food_log(text)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python -m food_file_reader <file_path>")
+        sys.exit(1)
+    result = parse_food_file(sys.argv[1])
+    print(result)

--- a/genie_service/functions/tests/test_food_file_reader.py
+++ b/genie_service/functions/tests/test_food_file_reader.py
@@ -1,0 +1,21 @@
+import unittest
+import os
+from tempfile import NamedTemporaryFile
+
+from genie_service.functions.food_file_reader import parse_food_file
+
+
+class TestFoodFileReader(unittest.TestCase):
+    def test_parse_file(self):
+        with NamedTemporaryFile('w+', delete=False, encoding='utf-8') as f:
+            f.write('사과 2개 먹었어요')
+            file_path = f.name
+        try:
+            data = parse_food_file(file_path)
+            self.assertEqual(data, {'food': 'apple', 'quantity': 2, 'measure': 'unit'})
+        finally:
+            os.remove(file_path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow parsing food logs from a text file via `food_file_reader.py`
- test reading and parsing using a temporary file

## Testing
- `PYTHONPATH=. pytest genie_service/functions/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68493a20c698832988b9ec2e8a9194c9