### PR TITLE
Add ChatGPT food parsing helper

### DIFF
--- a/genie_service/functions/chatgpt_food_parser.py
+++ b/genie_service/functions/chatgpt_food_parser.py
@@ -1,0 +1,49 @@
+import json
+from typing import List, Dict
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - openai may not be installed in tests
+    openai = None
+
+SYSTEM_PROMPT = (
+    "음식 섭취 문장을 받아서 {\"food\": <음식>, \"count\": <숫자>} 형식의 JSON만 반환해 주세요."
+)
+
+
+def _require_openai():
+    if openai is None:
+        raise ImportError("openai package is required to use this function")
+
+
+def parse_food_with_chatgpt(text: str) -> Dict[str, object]:
+    """Parse a single sentence describing food intake using ChatGPT."""
+    _require_openai()
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": text},
+    ]
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=messages,
+        temperature=0,
+    )
+    return json.loads(response.choices[0].message.content)
+
+
+def parse_food_list_to_json(sentences: List[str], path: str) -> None:
+    """Parse multiple sentences and save the result to a JSON file."""
+    data = [parse_food_with_chatgpt(s) for s in sentences]
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage helper
+    import sys
+
+    if len(sys.argv) < 3:
+        print("Usage: python -m chatgpt_food_parser '<sentence1>' '<sentence2>' ... <out_file>")
+        sys.exit(1)
+    *sentences, out_file = sys.argv[1:]
+    parse_food_list_to_json(sentences, out_file)
+    print(f"Saved results to {out_file}")

--- a/genie_service/functions/tests/test_chatgpt_food_parser.py
+++ b/genie_service/functions/tests/test_chatgpt_food_parser.py
@@ -1,0 +1,46 @@
+import json
+import os
+import unittest
+from tempfile import NamedTemporaryFile
+from unittest.mock import MagicMock, patch
+
+from genie_service.functions.chatgpt_food_parser import (
+    parse_food_with_chatgpt,
+    parse_food_list_to_json,
+)
+
+
+class TestChatGPTFoodParser(unittest.TestCase):
+    @patch("genie_service.functions.chatgpt_food_parser.openai")
+    def test_parse_food_with_chatgpt(self, mock_openai):
+        mock_openai.ChatCompletion.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content='{"food": "apple", "count": 1}'))]
+        )
+        result = parse_food_with_chatgpt("사과 1개를 먹었어요")
+        self.assertEqual(result, {"food": "apple", "count": 1})
+
+    @patch("genie_service.functions.chatgpt_food_parser.parse_food_with_chatgpt")
+    def test_parse_food_list_to_json(self, mock_parse):
+        mock_parse.side_effect = [
+            {"food": "apple", "count": 1},
+            {"food": "fish", "count": 1},
+        ]
+        with NamedTemporaryFile("r+", delete=False) as f:
+            out_path = f.name
+        try:
+            parse_food_list_to_json([
+                "사과 1개를 먹었어요",
+                "갈치구이를 먹었어요",
+            ], out_path)
+            with open(out_path, "r", encoding="utf-8") as fp:
+                data = json.load(fp)
+            self.assertEqual(
+                data,
+                [{"food": "apple", "count": 1}, {"food": "fish", "count": 1}],
+            )
+        finally:
+            os.remove(out_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- provide `chatgpt_food_parser` module for parsing food logs using ChatGPT
- add tests mocking the OpenAI API

## Testing
- `PYTHONPATH=. pytest genie_service/functions/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68493f71561c8329a37f6940dc566188